### PR TITLE
change var to import to solve using  https-proxy-agent  have the error: "HttpsProxyAgent is not a constructor"

### DIFF
--- a/docs/docs/guides/corporate-proxies/corporate-proxy.md
+++ b/docs/docs/guides/corporate-proxies/corporate-proxy.md
@@ -24,7 +24,7 @@ index 77161bd..1082fba 100644
 
  var _openidClient = require("openid-client");
 
-+var HttpsProxyAgent = require("https-proxy-agent");
++import { HttpsProxyAgent } from 'https-proxy-agent';
 +
  async function openidClient(options) {
    const provider = options.provider;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

> _NOTE_:
>
> - It's a good idea to open an issue first to discuss potential changes.
> - Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->
Just change the document, this waste me a lot of time to debug.
I want other people who need to access by proxy can be easier than me.

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: INSERT_ISSUE_LINK_HERE

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
